### PR TITLE
fixed receiving nearby mssages when getting messages from iOS devices

### DIFF
--- a/messages/NearbyDevices/app/src/main/java/com/google/android/gms/nearby/messages/samples/nearbydevices/DeviceMessage.java
+++ b/messages/NearbyDevices/app/src/main/java/com/google/android/gms/nearby/messages/samples/nearbydevices/DeviceMessage.java
@@ -31,11 +31,9 @@ public class DeviceMessage {
      * Creates a {@code DeviceMessage} object from the string used to construct the payload to a
      * {@code Nearby} {@code Message}.
      */
-    public static DeviceMessage fromNearbyMessage(Message message) {
+    public static String fromNearbyMessage(Message message) {
         String nearbyMessageString = new String(message.getContent()).trim();
-        return gson.fromJson(
-                (new String(nearbyMessageString.getBytes(Charset.forName("UTF-8")))),
-                DeviceMessage.class);
+        return (new String(nearbyMessageString.getBytes(Charset.forName("UTF-8"))));
     }
 
     private DeviceMessage(String instanceId) {

--- a/messages/NearbyDevices/app/src/main/java/com/google/android/gms/nearby/messages/samples/nearbydevices/MainFragment.java
+++ b/messages/NearbyDevices/app/src/main/java/com/google/android/gms/nearby/messages/samples/nearbydevices/MainFragment.java
@@ -199,7 +199,7 @@ public class MainFragment extends Fragment implements GoogleApiClient.Connection
                     @Override
                     public void run() {
                         mNearbyDevicesArrayAdapter.add(
-                                DeviceMessage.fromNearbyMessage(message).getMessageBody());
+                                DeviceMessage.fromNearbyMessage(message));
                     }
                 });
             }
@@ -211,7 +211,7 @@ public class MainFragment extends Fragment implements GoogleApiClient.Connection
                     @Override
                     public void run() {
                         mNearbyDevicesArrayAdapter.remove(
-                                DeviceMessage.fromNearbyMessage(message).getMessageBody());
+                                DeviceMessage.fromNearbyMessage(message));
                     }
                 });
             }


### PR DESCRIPTION
Gson will cause Android to crash when receiving messages from iOS. I removed it so it can communicate properly with iOS devices
