### PR TITLE
Update 'compile' to 'implementation'

### DIFF
--- a/connections/README.md
+++ b/connections/README.md
@@ -7,9 +7,9 @@ of network connectivity.
 
 Where to Download
 ---------------
-```groovy
+```
 dependencies {
-  compile 'com.google.android.gms:play-services-nearby:11.8.0'
+  implementation 'com.google.android.gms:play-services-nearby:11.8.0'
 }
 ```
 


### PR DESCRIPTION
In connections/ in the '[where to download](https://github.com/googlesamples/android-nearby/tree/master/connections#where-to-download)' section of the README, there is the following:

```
dependencies {
  compile 'com.google.android.gms:play-services-nearby:11.8.0'
}
```

Since 'compile' will be obsolete by the end of the year, I propose to update it to the following (change 'compile' to implementation):

```
dependencies {
  implementation 'com.google.android.gms:play-services-nearby:11.8.0'
}
```

(I've also changed the source code language of the code snippet from Groovy to nothing)

