### PR TITLE
Update compile to implementation

### DIFF
--- a/connections/README.md
+++ b/connections/README.md
@@ -7,9 +7,9 @@ of network connectivity.
 
 Where to Download
 ---------------
-```groovy
+```
 dependencies {
-  compile 'com.google.android.gms:play-services-nearby:11.8.0'
+  implementation 'com.google.android.gms:play-services-nearby:11.8.0'
 }
 ```
 


### PR DESCRIPTION
In connections/ in the '[where to download](https://github.com/knjk04/android-nearby/tree/compile-to-implementation/connections#where-to-download)' section, I have changed 'compile' to 'implementation' since compile will be obsolete by the end of the year. 

(I have also removed Groovy as the source language for the code snippet)